### PR TITLE
Add new reference for BUGS from EGUSphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please feel free to make additions, keeping the lists in chronologic order (by y
 * Retraction: How birds outperform humans in multi-component behavior, Sara Letzner, Onur Güntürkün, and Christian Beste, Current Biology Magazine, 2017. https://doi.org/10.1016/j.cub.2017.07.056
 * Characterization of Leptazolines A–D, Polar Oxazolines from the Cyanobacterium Leptolyngbya sp., Reveals a Glitch with the “Willoughby–Hoye” Scripts for Calculating NMR Chemical Shifts, Jayanti Bhandari Neupane, Ram P. Neupane, Yuheng Luo, Wesley Y. Yoshida, Rui Sun, and Philip G. Williams, Organic Letters, 2019. https://doi.org/10.1021/acs.orglett.9b03216
 * Covid: how Excel may have caused loss of 16,000 test results in England, Alex Hern, The Guardian, 2020. https://www.theguardian.com/politics/2020/oct/05/how-excel-may-have-caused-loss-of-16000-covid-tests-in-england
-* A case for open communication of bugs in climate models, made with ICON version 2024.01, Proske, U., Brüggemann, N., Gärtner, J. P., Gutjahr, O., Haak, H., Putrasahan, D., and Wieners, K.-H., EGUsphere  https://doi.org/10.5194/egusphere-2024-3493
+* A case for open communication of bugs in climate models, made with ICON version 2024.01, Proske, U., Brüggemann, N., Gärtner, J. P., Gutjahr, O., Haak, H., Putrasahan, D., and Wieners, K.-H., EGUsphere, 2024.  https://doi.org/10.5194/egusphere-2024-3493
 
 ## Collections
 


### PR DESCRIPTION
Not a retraction, but this links an interesting article that details a scientific bug in a climate model that was resolved, and a study published around it regarding why this communication is important in large shared models.

Unfortunately the preprint was rejected (regular publication of software vs new science issues) but it has led to a campaign for EGU special journals to document/report bugs or surprising flaws in models that come from study and has also led to conference sesisons at last year and this year's EGU which may contain further examples: https://meetingorganizer.copernicus.org/EGU25/session/52496

Let me know if you want this contribution and if I should also add the conference session as a collection.