### PR TITLE
ci: Adds workflow to update references.bib on pull requests

### DIFF
--- a/.github/workflows/update-references.yaml
+++ b/.github/workflows/update-references.yaml
@@ -1,0 +1,48 @@
+name: Update BibTeX references
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+    paths:
+      - "README.md"
+
+jobs:
+  update-references:
+    name: Update references.bib
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Convert doi to bibtex
+        run:
+          ./doi2bibtex > references.bib
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if [[ -n "$(git diff --exit-code)" ]]; then
+            echo "Changes detected."
+            echo "::set-output name=has_changes::true"
+          else
+            echo "No changes detected."
+            echo "::set-output name=has_changes::false"
+          fi
+      - name: Commit and push changes
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          # configure user
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+          # stage any file changes to be committed
+          git add -u .
+
+          # make commit with staged changes
+          git commit -m 'update: DOI changes to README.md, references.bib updated'
+
+          # push the commit back up to source GitHub repository
+          git push

--- a/doi2bibtex
+++ b/doi2bibtex
@@ -55,8 +55,8 @@ fi
 _fetch()
 {
   DOI=${1}
-  # echo "${DOI}"
-  curl -LH "Accept: text/bibliography; style=bibtex" ${DOI}
+  # Pipe through grep so that only valid references are output, we capture non-matches (when grep returns 1)
+  curl --silent -LH "Accept: text/bibliography; style=bibtex" ${DOI} | { grep "^ @" || test $? = 1; }
 }
 
 


### PR DESCRIPTION
Closes #23
Partially addresses #26

- `.github/workflows/update-references.yaml` which runs on pull requests that include changes to `README.md`
  - Clones the repository
  - Runs `./doi2bibtex`
  - Checks if there are changes to any files (only changes will be to `references.bib` if there are new DOI in
    `README.md`)
  - If so stage and commit the changes then push back to branch

Issue #26 details an invalid DOI. To handle this `doi2bibtex` has been updated and the results of the call to `curl` are pipped through `grep "^ @"` which filters out the HTML returned when a DOI does not resolve, leaving only valid BibTeX entries. When `grep` fails to find a match (on DOIs that don't resolve) it returns `1` which is captured so the script continues. 

I've run this locally using [`act`](https://github.com/nektos/act) and it appears to work ok, the `./doi2bibtex > references.bib` runs and the changes are detected, staged and committed. I've not tested the pushing step yet though. :crossed_fingers: 
